### PR TITLE
fix: instance_profile_role_name pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ module "castai-eks-iam-role" {
   aws_cluster_vpc_id = var.aws_vpc_id
   aws_cluster_region = var.aws_cluster_region
   aws_cluster_name   = var.aws_cluster_name
+  castai_cluster_id  = var.castai_cluster_id
 }
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ locals {
   iam_role_name              = "castai-eks-${substr(local.resource_name_postfix, 0, 53)}"
   iam_policy_name            = var.create_iam_resources_per_cluster ? "CastEKSPolicy-${local.resource_name_postfix}" : "CastEKSPolicy-tf"
   iam_role_policy_name       = "castai-user-policy-${substr(local.resource_name_postfix, 0, 45)}"
-  instance_profile_role_name = "castai-eks-instance-${substr(local.resource_name_postfix, 0, 44)}"
+  instance_profile_role_name = "cast-${substr(local.resource_name_postfix, 0, 40)}-eks-${substr(var.castai_cluster_id, 0, 8)}"
   iam_policy_prefix          = "arn:${data.aws_partition.current.partition}:iam::aws:policy"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -29,3 +29,8 @@ variable "castai_user_arn" {
   description = "ARN of CAST AI user for which AssumeRole trust access should be granted"
   default     = ""
 }
+
+variable "castai_cluster_id" {
+  type        = string
+  description = "ID of CAST AI cluster"
+}


### PR DESCRIPTION
As per requirement, the AWS IAM Instance Profile name must match `cast-${CLUSTER_NAME:0:40}-eks-${CASTAI_CLUSTER_ID:0:8}`, otherwise the following error will be thrown:

![image](https://github.com/user-attachments/assets/48962a3f-b741-4ba3-832e-7981ccce466f)

And, after a while, or upon triggering reconciliated, the status updates to _Failed_. 