### PR TITLE
Make castai_user_arn var required

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ module "castai-eks-role-iam" {
   aws_cluster_vpc_id = var.aws_vpc_id
   aws_cluster_region = var.aws_cluster_region
   aws_cluster_name   = var.aws_cluster_name
+  castai_user_arn    = var.castai_user_arn
 }
 ```
 

--- a/variables.tf
+++ b/variables.tf
@@ -27,7 +27,6 @@ variable "aws_account_id" {
 variable "castai_user_arn" {
   type        = string
   description = "ARN of CAST AI user for which AssumeRole trust access should be granted"
-  default     = ""
 }
 
 variable "attach_worker_cni_policy" {


### PR DESCRIPTION
Currently when user does not set the castai_user_arn variable, the IAM role creation will fail, due to the policy pricipal being invalid. The error the user will see is:
```
╷
│ Error: creating IAM Role (castai-eks-eks-2611-az): operation error IAM: CreateRole, https response error StatusCode: 400, RequestID: 9ed11c7e-cfd0-478a-8fcc-251557802ff2, MalformedPolicyDocument: Invalid principal in policy: "AWS":""
│
│   with module.castai-eks-iam-role.aws_iam_role.cast_role,
│   on ../../../terraform-castai-eks-role-iam/main.tf line 33, in resource "aws_iam_role" "cast_role":
│   33: resource "aws_iam_role" "cast_role" {
```

After the castai_user_arn variable is set, the role is created as expected:
```
castai_user_arn = castai_eks_user_arn.castai_user_arn.arn

module.castai-eks-iam-role.aws_iam_role.cast_role: Creating...
module.castai-eks-iam-role.aws_iam_role.cast_role: Creation complete after 6s [id=castai-eks-eks-2611-az]
```

To avoid users hitting this problem this variable should be required, which means the default should be removed. I have also updated the example inside README to include this as well. 

My only concern here is that this might affect existing clients, but I don't think any working setup won't have the castai_user_arn variable value explicitly set, so I think we should be good to go. 