### PR TITLE
feat: adds support for configurable max_session_duration and session tagging

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -59,6 +59,7 @@ resource "aws_iam_role_policy" "castai_role_iam_policy" {
 
 resource "aws_iam_role" "instance_profile_role" {
   name = local.instance_profile_role_name
+  max_session_duration =  var.max_session_duration
   assume_role_policy = jsonencode({
     Version : "2012-10-17"
     Statement : [
@@ -68,7 +69,10 @@ resource "aws_iam_role" "instance_profile_role" {
         Principal = {
           Service = "ec2.amazonaws.com"
         }
-        Action = ["sts:AssumeRole"]
+        "Action": [
+            "sts:AssumeRole",
+            "sts:TagSession"
+        ]
       }
     ]
   })

--- a/variables.tf
+++ b/variables.tf
@@ -40,3 +40,9 @@ variable "enable_ipv6" {
   description = "Whether to enable IPv6 CNI policy for the cluster."
   default     = true
 }
+
+variable "max_session_duration" {
+  description = "Maximum session duration (in seconds) that you want to set for the specified role."
+  type        = number
+  default     = 3600
+}


### PR DESCRIPTION
Adds support for configuring the `max_session_duration` for IAM roles via a variable, allowing to define session expiration limits as needed. 
It also includes `sts:TagSession` in the role's assume policy to enable session tagging.