### PR TITLE
feat: allow to pass external_id for CAST AI role - CSU-3532

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,10 +14,10 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       name: Checkout source code
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       name: Cache plugin dir
       with:
         path: ~/.tflint.d/plugins

--- a/main.tf
+++ b/main.tf
@@ -116,16 +116,21 @@ resource "aws_iam_role_policy_attachment" "attach_ec2_assign_ipv6" {
 
 data "aws_iam_policy_document" "cast_assume_role_policy" {
   statement {
-    sid = ""
-
-    actions = [
-      "sts:AssumeRole",
-    ]
+    sid     = ""
+    actions = ["sts:AssumeRole"]
 
     principals {
       type        = "AWS"
       identifiers = [var.castai_user_arn]
     }
+
+    dynamic "condition" {
+      for_each = var.castai_user_external_id!= null ? [1] : []
+      content {
+        test     = "StringEquals"
+        variable = "sts:ExternalId"
+        values   = [var.castai_user_external_id]
+      }
+    }
   }
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -46,3 +46,9 @@ variable "max_session_duration" {
   type        = number
   default     = 3600
 }
+
+variable "castai_user_external_id" {
+  description = "Optional external ID used in assume role policy condition"
+  type        = string
+  default     = null # Null because of backwards compatibility
+}


### PR DESCRIPTION
Usage

```
 # Create AWS IAM policies and a user to connect to CAST AI.
module "castai-eks-role-iam" {

  aws_account_id     = data.aws_caller_identity.current.account_id
  aws_cluster_region = var.cluster_region
  aws_cluster_name   = var.cluster_name
  aws_cluster_vpc_id = module.vpc.vpc_id

  castai_user_arn = castai_eks_user_arn.castai_user_arn.arn
  
  castai_user_external_id = castai_eks_clusterid.cluster_id.id

  create_iam_resources_per_cluster = true
}
```


https://castai.atlassian.net/browse/CSU-3532