### PR TITLE
fix: prevent dynamic resource names by excluding dynamic values from for_each

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,11 +9,11 @@ locals {
   ipv6_policy_name           = "CastEC2AssignIPv6Policy-${local.resource_name_postfix}"
 
   castai_instance_profile_policy_list = flatten([
-    "${local.iam_policy_prefix}/AmazonEKSWorkerNodePolicy",
-    "${local.iam_policy_prefix}/AmazonEC2ContainerRegistryReadOnly",
-    var.attach_worker_cni_policy ? ["${local.iam_policy_prefix}/AmazonEKS_CNI_Policy"] : [],
-    var.attach_ebs_csi_driver_policy ? ["${local.iam_policy_prefix}/service-role/AmazonEBSCSIDriverPolicy"] : [],
-    var.attach_ssm_managed_instance_core ? ["${local.iam_policy_prefix}/AmazonSSMManagedInstanceCore"] : []
+    "AmazonEKSWorkerNodePolicy",
+    "AmazonEC2ContainerRegistryReadOnly",
+    var.attach_worker_cni_policy ? ["AmazonEKS_CNI_Policy"] : [],
+    var.attach_ebs_csi_driver_policy ? ["service-role/AmazonEBSCSIDriverPolicy"] : [],
+    var.attach_ssm_managed_instance_core ? ["AmazonSSMManagedInstanceCore"] : []
   ])
 }
 
@@ -45,11 +45,11 @@ resource "aws_iam_policy" "castai_iam_policy" {
 
 resource "aws_iam_role_policy_attachment" "castai_iam_readonly_policy_attachment" {
   for_each = toset([
-    "${local.iam_policy_prefix}/AmazonEC2ReadOnlyAccess",
-    "${local.iam_policy_prefix}/IAMReadOnlyAccess",
+    "AmazonEC2ReadOnlyAccess",
+    "IAMReadOnlyAccess",
   ])
   role       = aws_iam_role.cast_role.name
-  policy_arn = each.value
+  policy_arn = "${local.iam_policy_prefix}/${each.value}"
 }
 
 resource "aws_iam_role_policy" "castai_role_iam_policy" {
@@ -89,7 +89,7 @@ resource "aws_iam_role_policy_attachment" "castai_instance_profile_policy" {
   for_each = toset(local.castai_instance_profile_policy_list)
 
   role       = aws_iam_instance_profile.instance_profile.role
-  policy_arn = each.value
+  policy_arn = "${local.iam_policy_prefix}/${each.value}"
 }
 
 # Create the IAM Policy for IPv6 assignment


### PR DESCRIPTION
```
│ Error: Invalid for_each argument
│
│   on .terraform/modules/iam.castai-eks-role-iam/main.tf line 47, in resource "aws_iam_role_policy_attachment" "castai_iam_readonly_policy_attachment":
│   47:   for_each = toset([
│   48:     "${local.iam_policy_prefix}/AmazonEC2ReadOnlyAccess",
│   49:     "${local.iam_policy_prefix}/IAMReadOnlyAccess",
│   50:   ])
│     ├────────────────
│     │ local.iam_policy_prefix is a string, known only after apply
│
│ The "for_each" set includes values derived from resource attributes that cannot be determined until apply, and so OpenTofu cannot determine the full set of keys that will identify the instances of this resource.
│
│ When working with unknown values in for_each, it's better to use a map value where the keys are defined statically in your configuration and where only the values contain apply-time results.
│
│ Alternatively, you could use the planning option -exclude=module.iam\[0\].module.castai-eks-role-iam.aws_iam_role_policy_attachment.castai_iam_readonly_policy_attachment to first apply without this object, and then apply normally to converge.
╵
╷
│ Error: Invalid for_each argument
│
│   on .terraform/modules/iam.castai-eks-role-iam/main.tf line 89, in resource "aws_iam_role_policy_attachment" "castai_instance_profile_policy":
│   89:   for_each = toset(local.castai_instance_profile_policy_list)
│     ├────────────────
│     │ local.castai_instance_profile_policy_list is tuple with 5 elements
│
│ The "for_each" set includes values derived from resource attributes that cannot be determined until apply, and so OpenTofu cannot determine the full set of keys that will identify the instances of this resource.
│
│ When working with unknown values in for_each, it's better to use a map value where the keys are defined statically in your configuration and where only the values contain apply-time results.
│
│ Alternatively, you could use the planning option -exclude=module.iam\[0\].module.castai-eks-role-iam.aws_iam_role_policy_attachment.castai_instance_profile_policy to first apply without this object, and then apply normally to converge.
╵
```

The above occurs if one has a `module "castai-eks-role-iam"` + a `depends_on = [<eks cluster resource>] on the castai-eks-role-iam` module (*).

I believe it happens because all resource keys must be evaluated on `tofu plan`, but given the module `depends_on` not-yet-created resource - it fails to evaluate the resource key, hence failing the plan.

The issue itself should not create any duplicate keys, given existing for_each entries are unique atm.