### PR TITLE
Issue #20613 - Fix eliminating toset from the policy attachment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,10 +44,11 @@ resource "aws_iam_policy" "castai_iam_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "castai_iam_readonly_policy_attachment" {
-  for_each = toset([
-    "${local.iam_policy_prefix}/AmazonEC2ReadOnlyAccess",
-    "${local.iam_policy_prefix}/IAMReadOnlyAccess",
-  ])
+  for_each = {
+    ec2 = "${local.iam_policy_prefix}/AmazonEC2ReadOnlyAccess"
+    iam = "${local.iam_policy_prefix}/IAMReadOnlyAccess"
+  }
+
   role       = aws_iam_role.cast_role.name
   policy_arn = each.value
 }
@@ -86,7 +87,7 @@ resource "aws_iam_instance_profile" "instance_profile" {
 }
 
 resource "aws_iam_role_policy_attachment" "castai_instance_profile_policy" {
-  for_each = toset(local.castai_instance_profile_policy_list)
+  for_each = { for idx, arn in local.castai_instance_profile_policy_list : idx => arn }
 
   role       = aws_iam_instance_profile.instance_profile.role
   policy_arn = each.value


### PR DESCRIPTION
Refactored the IAM policy attachment logic to improve compatibility and avoid issues with `toset()`.

* Added `data "aws_caller_identity" "current"` for proper AWS account resolution.
* Replaced `for_each = toset(local.castai_instance_profile_policy_list)` with a map comprehension (`{ for idx, arn in local.castai_instance_profile_policy_list : idx => arn }`) to ensure stable keys and handle duplicates safely.

This should make the module more reliable across different environments and Terraform/Terragrunt runs.


<img width="1342" height="879" alt="issue_20613" src="https://github.com/user-attachments/assets/c8937e12-d285-4b55-a602-4f2e27a9975c" />
