### PR TITLE
fix: update min castai provider version to 8.11

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     castai = {
       source  = "castai/castai"
-      version = ">= 7.13"
+      version = ">= 8.11"
     }
   }
 }


### PR DESCRIPTION
PR #31 introduced a variable only available in castai provider 8.11 and above. Using an older provider version with this module will cause Terraform to fail.